### PR TITLE
Cookies string splitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Accepts a single `set-cookie` header value, an array of `set-cookie` header values, or a Node.js response object that may have 0 or more `set-cookie` headers.
 
-Also accepts an optional options object. Defaults: 
+Also accepts an optional options object. Defaults:
 
 ```js
 {
@@ -19,7 +19,7 @@ Always returns an array of cookie objects. Each object will have, at a minimum a
 * domain - domain for the cookie (string or undefined, may begin with "." to indicate the named domain or any subdomain of it)
 * expires - absolute expiration date for the cookie (Date object or undefined)
 * maxAge - relative max age of the cookie in seconds from when the client receives it (integer or undefined)
- * Note: when using with [express's res.cookie() method](http://expressjs.com/en/4x/api.html#res.cookie), multiply `maxAge` by 1000 to convert to miliseconds. 
+ * Note: when using with [express's res.cookie() method](http://expressjs.com/en/4x/api.html#res.cookie), multiply `maxAge` by 1000 to convert to miliseconds.
 * secure - indicates that this cookie should only be sent over HTTPs (true or undefined)
 * httpOnly - indicates that this cookie should *not* be accessible to client-side JavaScript (true or undefined)
 * sameSite - indicates a cookie ought not to be sent along with cross-site requests (string or undefined)
@@ -46,6 +46,16 @@ http.get('http://example.com', function(res) {
 
   cookies.forEach(console.log);
 }
+
+var splitCookiesString = setCookie.splitCookiesString;
+
+var cookies = splitCookiesString('sessionid=123 expires=Thu, 04-Jun-2020 12:17:56 GMT, cid=ABC');
+
+console.log(cookies);
+// [
+//   'sessionid=123 expires=Thu, 04-Jun-2020 12:17:56 GMT',
+//   'cid=ABC',
+// ]
 ```
 
 Example output:

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -70,5 +70,89 @@ function parse(input, options) {
   });
 }
 
+/*
+  Set-Cookie returned from fetch() are comma joined in one string.
+  Some cookies parameters like expires include commas as well.
+  This function split string containing multiple cookies into array of single cookie strings
+
+  Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+  Credits to: https://github.com/tomball
+*/
+function splitCookiesString(cookiesString) {
+  if (Array.isArray(cookiesString)) {
+    return cookiesString;
+  }
+  if (typeof cookiesString !== 'string') {
+    return [];
+  }
+
+
+  const cookiesStrings = [];
+  let pos = 0;
+  let start;
+  let ch;
+  let lastComma;
+  let nextStart;
+  let cookiesSeparatorFound;
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1;
+    }
+    return pos < cookiesString.length;
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos);
+
+    return ch !== '=' && ch !== ';' && ch !== ',';
+  }
+
+
+  while (pos < cookiesString.length) {
+    start = pos;
+    cookiesSeparatorFound = false;
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos);
+      if (ch === ',') {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos;
+        pos += 1;
+
+        skipWhitespace();
+        nextStart = pos;
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1;
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === '=') {
+          // we found cookies separator
+          cookiesSeparatorFound = true;
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart;
+          cookiesStrings.push(cookiesString.substring(start, lastComma));
+          start = pos;
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1;
+        }
+      } else {
+        pos += 1;
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length));
+    }
+  }
+
+  return cookiesStrings;
+}
+
 module.exports = parse;
 module.exports.parse = parse;
+module.exports.splitCookiesString = splitCookiesString;

--- a/test/index.js
+++ b/test/index.js
@@ -115,7 +115,7 @@ describe('splitCookiesString', function () {
   });
 
   it('should parse empty string', function () {
-    var actual = splitCookiesString(1);
+    var actual = splitCookiesString('');
     var expected = [];
     assert.deepEqual(actual, expected);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -73,3 +73,180 @@ describe('set-cookie-parser', function () {
   });
 
 });
+
+const splitCookiesString = setCookie.splitCookiesString;
+
+const array = ['a', 'b'];
+
+const cookieNoParams = 'sessionid=6ky4pkr7qoi4me7rwleyvxjove25huef';
+const cookieWithParams = `${cookieNoParams}; HttpOnly; Path=/`;
+const cookieWithExpires = 'cid=70125eaa-399a-41b2-b235-8a5092042dba; expires=Thu, 04-Jun-2020 12:17:56 GMT; Max-Age=63072000; Path=/; HttpOnly; Secure';
+const cookieWithExpiresAtEnd = 'client_id=70125eaa-399a-41b2-b235-8a5092042dba; Max-Age=63072000; Path=/; expires=Thu, 04-Jun-2020 12:17:56 GMT';
+
+const firstWithParamSecondNoParam = `${cookieWithParams}, ${cookieNoParams}`;
+const threeNoParams = `${cookieNoParams}, ${cookieNoParams}, ${cookieNoParams}`;
+const threeWithParams = `${cookieWithParams}, ${cookieWithParams}, ${cookieWithParams}`;
+const firstWithExpiresSecondNoParam = `${cookieWithExpires}, ${cookieNoParams}`;
+const firstWithExpiresSecondWithParam = `${cookieWithExpires}, ${cookieWithParams}`;
+const firstWithExpiresAtEndSecondNoParam = `${cookieWithExpiresAtEnd}, ${cookieNoParams}`;
+const firstWithExpiresAtEndSecondWithParam = `${cookieWithExpiresAtEnd}, ${cookieWithParams}`;
+const firstWithExpiresSecondWithExpires = `${cookieWithExpires}, ${cookieWithExpires}`;
+const firstWithExpiresSecondWithExpiresAtEnd = `${cookieWithExpires}, ${cookieWithExpiresAtEnd}`;
+const firstWithExpiresAtEndSecondWithExpires = `${cookieWithExpiresAtEnd}, ${cookieWithExpires}`;
+const firstWithExpiresAtEndSecondWithExpiresAtEnd = `${cookieWithExpiresAtEnd}, ${cookieWithExpiresAtEnd}`;
+const firstWithExpiresSecondWithExpiresAtEndThirdWithExpires = `${cookieWithExpires}, ${cookieWithExpiresAtEnd}, ${cookieWithExpires}`;
+const firstWithExpiresSecondWithExpiresAtEndThirdWithExpiresAtEnd = `${cookieWithExpires}, ${cookieWithExpiresAtEnd}, ${cookieWithExpiresAtEnd}`;
+const threeWithExpires = `${cookieWithExpires}, ${cookieWithExpires}, ${cookieWithExpires}`;
+const threeWithExpiresAtEnd = `${cookieWithExpiresAtEnd}, ${cookieWithExpiresAtEnd}, ${cookieWithExpiresAtEnd}`;
+
+
+describe('splitCookiesString', function () {
+
+  it('should return array if Array', function () {
+    var actual = splitCookiesString(array);
+    var expected = array;
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should return empty array on non string type', function () {
+    var actual = splitCookiesString(1);
+    var expected = [];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse empty string', function () {
+    var actual = splitCookiesString(1);
+    var expected = [];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse single cookie without params', function () {
+    var actual = splitCookiesString(cookieNoParams);
+    var expected = [cookieNoParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse single cookie with params', function () {
+    var actual = splitCookiesString(cookieWithParams);
+    var expected = [cookieWithParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse three cookies without params', function (){
+    var actual = splitCookiesString(threeNoParams);
+    var expected = [cookieNoParams, cookieNoParams, cookieNoParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse Three with params', function () {
+    var actual = splitCookiesString(threeWithParams);
+    var expected = [cookieWithParams, cookieWithParams, cookieWithParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with params, second without params', function () {
+    var actual = splitCookiesString(firstWithParamSecondNoParam);
+    var expected = [cookieWithParams, cookieNoParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse single with expires', function () {
+    var actual = splitCookiesString(cookieWithExpires);
+    var expected = [cookieWithExpires];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse single with expires at end', function () {
+    var actual = splitCookiesString(cookieWithExpiresAtEnd);
+    var expected = [cookieWithExpiresAtEnd];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second without params', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondNoParam);
+    var expected = [cookieWithExpires, cookieNoParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second with params', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondWithParam);
+    var expected = [cookieWithExpires, cookieWithParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires at end, second without params', function () {
+    var actual = splitCookiesString(firstWithExpiresAtEndSecondNoParam);
+    var expected = [cookieWithExpiresAtEnd, cookieNoParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires at end, second with params', function () {
+    var actual = splitCookiesString(firstWithExpiresAtEndSecondWithParam);
+    var expected = [cookieWithExpiresAtEnd, cookieWithParams];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second with expires', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondWithExpires);
+    var expected = [cookieWithExpires, cookieWithExpires];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second with expires at end', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondWithExpiresAtEnd);
+    var expected = [cookieWithExpires, cookieWithExpiresAtEnd];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires at end, second with expires', function () {
+    var actual = splitCookiesString(firstWithExpiresAtEndSecondWithExpires);
+    var expected = [cookieWithExpiresAtEnd, cookieWithExpires];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires at end, second with expires at end', function () {
+    var actual = splitCookiesString(firstWithExpiresAtEndSecondWithExpiresAtEnd);
+    var expected = [cookieWithExpiresAtEnd, cookieWithExpiresAtEnd];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second with expires at end, third with expires', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondWithExpiresAtEndThirdWithExpires);
+    var expected = [
+        cookieWithExpires,
+        cookieWithExpiresAtEnd,
+        cookieWithExpires,
+      ];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse first with expires, second with expires at end, third with expires at end', function () {
+    var actual = splitCookiesString(firstWithExpiresSecondWithExpiresAtEndThirdWithExpiresAtEnd);
+    var expected = [
+        cookieWithExpires,
+        cookieWithExpiresAtEnd,
+        cookieWithExpiresAtEnd,
+      ];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse three with expires', function () {
+    var actual = splitCookiesString(threeWithExpires);
+    var expected = [
+        cookieWithExpires,
+        cookieWithExpires,
+        cookieWithExpires,
+      ];
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should parse three with expires at end', function () {
+    var actual = splitCookiesString(threeWithExpiresAtEnd);
+    var expected = [
+        cookieWithExpiresAtEnd,
+        cookieWithExpiresAtEnd,
+        cookieWithExpiresAtEnd,
+      ];
+    assert.deepEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
Set-Cookie header returned by few frameworks is a one string of comma separated cookie strings.
This PR adds method to split this string into array of separate cookie strings.
Handles commas in parameters like expires.

e.g. string:
```
"cid=70125eaa-399a-41b2-b235-8a5092042dba; expires=Thu, 04-Jun-2020 12:17:56 GMT; Max-Age=63072000; Path=/, client_id=70125eaa-399a-41b2-b235-8a5092042dba; Max-Age=63072000; Path=/; expires=Thu, 04-Jun-2020 12:17:56 GMT"
```
to array:
```
[
"cid=70125eaa-399a-41b2-b235-8a5092042dba; expires=Thu, 04-Jun-2020 12:17:56 GMT; Max-Age=63072000; Path=/",
"client_id=70125eaa-399a-41b2-b235-8a5092042dba; Max-Age=63072000; Path=/; expires=Thu, 04-Jun-2020 12:17:56 GMT",
]
```

Fixes #18 
Fixes #13