### PR TITLE
New map option to configure parser for cookie object

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Also accepts an optional options object. Defaults:
 ```js
 {
     decodeValues: true  // Calls dcodeURIComponent on each value - default: true
-    result: "list"      // Returns array of cookie objects
+    map: false          // Returns array of cookie objects - default: false
 }
 ```
 
-Returns either array of cookie objects or map of cookie objects based on `result` option. Each object will have, at a minimum a name and value and may have any of the other parameters depending on the set-cookie header:
+Returns either array of cookie objects or map of cookie objects based on `map` option. Each object will have, at a minimum a name and value and may have any of the other parameters depending on the set-cookie header:
 
 * name - cookie name (string)
 * value - cookie value (string)
@@ -57,7 +57,7 @@ var setCookie = require('set-cookie-parser');
 http.get('http://example.com', function(res) {
   var cookies = setCookie.parse(res, {
     decodeValues: true  // default: true
-    result: "map"       //default: "list"
+    map: true           //default: false
   });
 
   var desiredCookie = cookies[someCookieName];

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Also accepts an optional options object. Defaults:
 ```js
 {
     decodeValues: true  // Calls dcodeURIComponent on each value - default: true
+    result: "list"      // Returns array of cookie objects
 }
 ```
 
-Always returns an array of cookie objects. Each object will have, at a minimum a name and value and may have any of the other parameters depending on the set-cookie header:
+Returns either array of cookie objects or map of cookie objects based on `result` option. Each object will have, at a minimum a name and value and may have any of the other parameters depending on the set-cookie header:
 
 * name - cookie name (string)
 * value - cookie value (string)
@@ -35,6 +36,7 @@ $ npm install --save set-cookie-parser
 
 ## Usage
 
+Get array of cookie objects
 ```js
 var http = require('http');
 var setCookie = require('set-cookie-parser');
@@ -47,9 +49,25 @@ http.get('http://example.com', function(res) {
   cookies.forEach(console.log);
 }
 ```
+Get map of cookie objects
+```js
+var http = require('http');
+var setCookie = require('set-cookie-parser');
+
+http.get('http://example.com', function(res) {
+  var cookies = setCookie.parse(res, {
+    decodeValues: true  // default: true
+    result: "map"       //default: "list"
+  });
+
+  var desiredCookie = cookies[someCookieName];
+  console.log(desiredCookie);
+}
+```
 
 Example output:
 
+Array of cookie objects
 ```js
 [
     {
@@ -68,6 +86,27 @@ Example output:
         sameSite: 'lax'
     }
 ]
+```
+
+Map of cookie objects
+```js
+{
+    bam: {
+        name: 'bam',
+        value: 'baz'
+    },
+    foo: {
+        name: 'foo',
+        value: 'bar',
+        path: '/',
+        expires: new Date('Tue Jul 01 2025 06:01:11 GMT-0400 (EDT)'),
+        maxAge: 1000,
+        domain: '.example.com',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'lax'
+    }
+}
 ```
 
 ## Usage in React Native

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -2,7 +2,7 @@
 
 var defaultParseOptions = {
   decodeValues: true,
-  result: "list"
+  map: false
 };
 
 function extend(target, source) {
@@ -69,19 +69,17 @@ function parse(input, options) {
     options = defaultOptions;
   }
 
-  if (options.result === "list") {
+  if (!options.map) {
     return input.filter(isNonEmptyString).map(function(str) {
       return parseString(str, options);
     });
-  } else if (options.result === "map") {
+  } else {
     var cookies = {};
     return input.filter(isNonEmptyString).reduce(function(cookies, str) {
       var cookie = parseString(str, options);
       cookies[cookie.name] = cookie;
       return cookies;
     }, cookies);
-  } else {
-    throw new Error("Invalid parse option:" + String(options.result));
   }
 }
 

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var defaultParseOptions = {
-  decodeValues: true
+  decodeValues: true,
+  result: "list"
 };
 
 function extend(target, source) {
@@ -68,9 +69,20 @@ function parse(input, options) {
     options = defaultOptions;
   }
 
-  return input.filter(isNonEmptyString).map(function(str) {
-    return parseString(str, options);
-  });
+  if (options.result === "list") {
+    return input.filter(isNonEmptyString).map(function(str) {
+      return parseString(str, options);
+    });
+  } else if (options.result === "map") {
+    var cookies = {};
+    return input.filter(isNonEmptyString).reduce(function(cookies, str) {
+      var cookie = parseString(str, options);
+      cookies[cookie.name] = cookie;
+      return cookies;
+    }, cookies);
+  } else {
+    throw new Error("Invalid parse option:" + String(options.result));
+  }
 }
 
 /*

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,34 @@ describe("set-cookie-parser", function() {
     var expected = [];
     assert.deepEqual(actual, expected);
   });
+
+  it("should return object of cookies when result option is set to map", function() {
+    var cookieStr =
+      "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure";
+    var actual = setCookie.parse(cookieStr, { result: "map" });
+    var expected = {
+      foo: {
+        name: "foo",
+        value: "bar",
+        path: "/",
+        expires: new Date("Tue Jul 01 2025 06:01:11 GMT-0400 (EDT)"),
+        maxAge: 1000,
+        domain: ".example.com",
+        secure: true,
+        httpOnly: true
+      }
+    };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("should throw error when invalid result option is passed", function() {
+    var cookieString = "foo=bar;";
+    var options = { result: "invalid" };
+    var assertFn = function() {
+      return setCookie.parse(cookieString, options);
+    };
+    assert.throws(assertFn);
+  });
 });
 
 const splitCookiesString = setCookie.splitCookiesString;

--- a/test/index.js
+++ b/test/index.js
@@ -131,7 +131,7 @@ describe("set-cookie-parser", function() {
   it("should return object of cookies when result option is set to map", function() {
     var cookieStr =
       "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure";
-    var actual = setCookie.parse(cookieStr, { result: "map" });
+    var actual = setCookie.parse(cookieStr, { map: true });
     var expected = {
       foo: {
         name: "foo",
@@ -145,15 +145,6 @@ describe("set-cookie-parser", function() {
       }
     };
     assert.deepEqual(actual, expected);
-  });
-
-  it("should throw error when invalid result option is passed", function() {
-    var cookieString = "foo=bar;";
-    var options = { result: "invalid" };
-    var assertFn = function() {
-      return setCookie.parse(cookieString, options);
-    };
-    assert.throws(assertFn);
   });
 });
 


### PR DESCRIPTION
This option will allow users to configure cookie parser to create a map of cookie objects based on cookie names. Each key in this map will be cookie's name and it will be mapped to cookie object. Corresponding tests have also been added to confirm this option's working and also to detect invalid usage of this option.