### PR TITLE
Handle capitalized set-cookie key

### DIFF
--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -56,7 +56,7 @@ function parse(input, options) {
     return [];
   }
   if (input.headers) {
-    input = input.headers["set-cookie"];
+    input = input.headers["set-cookie"] || input.headers["Set-cookie"] || input.headers["Set-Cookie"];
   }
   if (!Array.isArray(input)) {
     input = [input];

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -56,7 +56,13 @@ function parse(input, options) {
     return [];
   }
   if (input.headers) {
-    input = input.headers["set-cookie"] || input.headers["Set-cookie"] || input.headers["Set-Cookie"];
+    input =
+      input.headers["set-cookie"] ||
+      input.headers[
+        Object.keys(input.headers).find(function(key) {
+          return key.toLowerCase() === "set-cookie";
+        })
+      ];
   }
   if (!Array.isArray(input)) {
     input = [input];

--- a/test/index.js
+++ b/test/index.js
@@ -119,6 +119,33 @@ describe("set-cookie-parser", function() {
     assert.deepEqual(actual, expected);
   });
 
+  it("should work with strangely capitalized set-cookie key", function() {
+    var mockRequest = {
+      headers: {
+        "sEt-CookIe": [
+          "bam=baz",
+          "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure; SameSite=strict"
+        ]
+      }
+    };
+    var actual = setCookie.parse(mockRequest);
+    var expected = [
+      { name: "bam", value: "baz" },
+      {
+        name: "foo",
+        value: "bar",
+        path: "/",
+        expires: new Date("Tue Jul 01 2025 06:01:11 GMT-0400 (EDT)"),
+        maxAge: 1000,
+        domain: ".example.com",
+        secure: true,
+        httpOnly: true,
+        sameSite: "strict"
+      }
+    ];
+    assert.deepEqual(actual, expected);
+  });
+
   it("should work on request objects that don't have any set-cookie headers", function() {
     var mockRequest = {
       headers: {}


### PR DESCRIPTION
Sometimes the `set-cookie` key is capitalized like `Set-cookie` or `Set-Cookie`. This change handle both.