### PR TITLE
return an empty map for falsy input when options.map is enabled

### DIFF
--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -48,13 +48,17 @@ function parseString(setCookieValue, options) {
 }
 
 function parse(input, options) {
-  if (!input) {
-    return [];
-  }
-
   options = options
     ? Object.assign({}, defaultParseOptions, options)
     : defaultParseOptions;
+
+  if (!input) {
+    if (!options.map) {
+      return [];
+    } else {
+      return {};
+    }
+  }
 
   if (input.headers && input.headers["set-cookie"]) {
     // fast-path for node.js (which automatically normalizes header names to lower-case

--- a/test/set-cookie-parser.js
+++ b/test/set-cookie-parser.js
@@ -9,6 +9,23 @@ describe("set-cookie-parser", function () {
     assert.deepEqual(actual, expected);
   });
 
+  it("should return empty array on falsy input", function () {
+    var cookieStr = "";
+    var actual = setCookie.parse(cookieStr);
+    var expected = [];
+    assert.deepEqual(actual, expected);
+
+    cookieStr = null;
+    actual = setCookie.parse(cookieStr);
+    expected = [];
+    assert.deepEqual(actual, expected);
+
+    cookieStr = undefined;
+    actual = setCookie.parse(cookieStr);
+    expected = [];
+    assert.deepEqual(actual, expected);
+  });
+
   it("should parse a complex set-cookie header", function () {
     var cookieStr =
       "foo=bar; Max-Age=1000; Domain=.example.com; Path=/; Expires=Tue, 01 Jul 2025 10:01:11 GMT; HttpOnly; Secure";
@@ -171,6 +188,23 @@ describe("set-cookie-parser", function () {
         httpOnly: true,
       },
     };
+    assert.deepEqual(actual, expected);
+  });
+
+  it("should return empty object on falsy input when result options is set to map", function () {
+    var cookieStr = "";
+    var actual = setCookie.parse(cookieStr, { map: true });
+    var expected = {};
+    assert.deepEqual(actual, expected);
+
+    cookieStr = null;
+    actual = setCookie.parse(cookieStr, { map: true });
+    expected = {};
+    assert.deepEqual(actual, expected);
+
+    cookieStr = undefined;
+    actual = setCookie.parse(cookieStr, { map: true });
+    expected = {};
     assert.deepEqual(actual, expected);
   });
 });


### PR DESCRIPTION
Noticed that when passing falsy input, an array was always returned even when options.map was true.

Simple addition to return an empty object on falsy input when options.map is true.

Also added tests for both the empty array and empty map case.