### PR TITLE
Handle the case where cookie value cannot be decoded.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 "use strict";
 module.exports = {
-  parserOptions: { ecmaVersion: 5 },
+  parserOptions: { ecmaVersion: 6 },
   env: {
     node: true,
     browser: true,

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -23,7 +23,7 @@ function parseString(setCookieValue, options) {
   try {
     value = options.decodeValues ? decodeURIComponent(value) : value; // decode cookie value
   } catch(e) {
-    console.error(e);
+    console.error(`set-cookie-parser encountered an error while decoding a cookie with value '${value}'. Set options.decodeValues to false to disable this feature.`, e);
   }
 
   var cookie = {

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -20,9 +20,15 @@ function parseString(setCookieValue, options) {
     ? Object.assign({}, defaultParseOptions, options)
     : defaultParseOptions;
 
+  try {
+    value = options.decodeValues ? decodeURIComponent(value) : value; // decode cookie value
+  } catch(e) {
+    console.error(e);
+  }
+
   var cookie = {
     name: name, // grab everything before the first =
-    value: options.decodeValues ? decodeURIComponent(value) : value, // decode cookie value
+    value: value,
   };
 
   parts.forEach(function (part) {

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -22,8 +22,11 @@ function parseString(setCookieValue, options) {
 
   try {
     value = options.decodeValues ? decodeURIComponent(value) : value; // decode cookie value
-  } catch(e) {
-    console.error(`set-cookie-parser encountered an error while decoding a cookie with value '${value}'. Set options.decodeValues to false to disable this feature.`, e);
+  } catch (e) {
+    console.error(
+      `set-cookie-parser encountered an error while decoding a cookie with value '${value}'. Set options.decodeValues to false to disable this feature.`,
+      e
+    );
   }
 
   var cookie = {

--- a/test/set-cookie-parser.js
+++ b/test/set-cookie-parser.js
@@ -87,6 +87,15 @@ describe("set-cookie-parser", function () {
     assert.deepEqual(actual, expected);
   });
 
+  it("should handle the case when value is not UTF-8 encoded", function () {
+    var cookieStr = "foo=R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A";
+    var actual = setCookie.parse(cookieStr, { decodeValues: true });
+    var expected = [
+      { name: "foo", value: "R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A" },
+    ];
+    assert.deepEqual(actual, expected);
+  });
+
   it("should work on an array of headers", function () {
     var cookieStrs = [
       "bam=baz",

--- a/test/set-cookie-parser.js
+++ b/test/set-cookie-parser.js
@@ -88,10 +88,15 @@ describe("set-cookie-parser", function () {
   });
 
   it("should handle the case when value is not UTF-8 encoded", function () {
-    var cookieStr = "foo=R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A";
+    var cookieStr =
+      "foo=R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A";
     var actual = setCookie.parse(cookieStr, { decodeValues: true });
     var expected = [
-      { name: "foo", value: "R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A" },
+      {
+        name: "foo",
+        value:
+          "R%F3r%EB%80%8DP%FF%3B%2C%23%9A%0CU%8E%A2C8%D7%3C%3C%B0%DF%17%60%F7Y%DB%16%8BQ%D6%1A",
+      },
     ];
     assert.deepEqual(actual, expected);
   });


### PR DESCRIPTION
In some of cases there are possibilities when cookie value is not UTF-8 encoded and passing this to `decodeURIComponent` raises URIError: URI Malformed. Therefore, we may just log the exception and simply retain the original cookie value while not respecting whatever `options.decodeValues` asks.