### PR TITLE
Add sideEffects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lib"
   ],
   "main": "./lib/set-cookie.js",
+  "sideEffects": false,
   "keywords": [
     "set-cookie",
     "set",


### PR DESCRIPTION
Hi! We are trying to use this library in [@shopify/hydrogen](https://github.com/Shopify/hydrogen/pull/1427) but noticed it cannot be tree-shaked.

This PR adds `sideEffects` property to `package.json`,  which is useful to let bundlers like Webpack or Rollup know that this library can be [tree-shaked in ESM](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).

Related to #50 