### PR TITLE
Change name-value-pair parsing to follow 6265bis

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Returns an array of strings that may be passed to `parse()`.
 ## References
 
 * [RFC 6265: HTTP State Management Mechanism](https://tools.ietf.org/html/rfc6265)
+* [draft-ietf-httpbis-rfc6265bis-10](https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html)
 
 ## License
 

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -13,8 +13,8 @@ function isNonEmptyString(str) {
 function parseString(setCookieValue, options) {
   var parts = setCookieValue.split(";").filter(isNonEmptyString);
 
-  var nameValuePair = parts.shift();
-  var parsed = parseNameValuePair(nameValuePair);
+  var nameValuePairStr = parts.shift();
+  var parsed = parseNameValuePair(nameValuePairStr);
   var name = parsed.name;
   var value = parsed.value;
 
@@ -60,18 +60,17 @@ function parseString(setCookieValue, options) {
   return cookie;
 }
 
-function parseNameValuePair(nameValuePair) {
+function parseNameValuePair(nameValuePairStr) {
   // Parses name-value-pair according to rfc6265bis draft
 
   var name = "";
   var value = "";
-  if (nameValuePair.includes("=")) {
-    var nameValue = nameValuePair.split("=");
-    name = nameValue.shift();
-    value = nameValue.join("="); // everything after the first =, joined by a "=" if there was more than one part
+  var nameValueArr = nameValuePairStr.split("=");
+  if (nameValueArr.length > 1) {
+    name = nameValueArr.shift();
+    value = nameValueArr.join("="); // everything after the first =, joined by a "=" if there was more than one part
   } else {
-    name = "";
-    value = nameValuePair;
+    value = nameValuePairStr;
   }
 
   return { name: name, value: value };

--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -12,9 +12,11 @@ function isNonEmptyString(str) {
 
 function parseString(setCookieValue, options) {
   var parts = setCookieValue.split(";").filter(isNonEmptyString);
-  var nameValue = parts.shift().split("=");
-  var name = nameValue.shift();
-  var value = nameValue.join("="); // everything after the first =, joined by a "=" if there was more than one part
+
+  var nameValuePair = parts.shift();
+  var parsed = parseNameValuePair(nameValuePair);
+  var name = parsed.name;
+  var value = parsed.value;
 
   options = options
     ? Object.assign({}, defaultParseOptions, options)
@@ -32,7 +34,7 @@ function parseString(setCookieValue, options) {
   }
 
   var cookie = {
-    name: name, // grab everything before the first =
+    name: name,
     value: value,
   };
 
@@ -56,6 +58,23 @@ function parseString(setCookieValue, options) {
   });
 
   return cookie;
+}
+
+function parseNameValuePair(nameValuePair) {
+  // Parses name-value-pair according to rfc6265bis draft
+
+  var name = "";
+  var value = "";
+  if (nameValuePair.includes("=")) {
+    var nameValue = nameValuePair.split("=");
+    name = nameValue.shift();
+    value = nameValue.join("="); // everything after the first =, joined by a "=" if there was more than one part
+  } else {
+    name = "";
+    value = nameValuePair;
+  }
+
+  return { name: name, value: value };
 }
 
 function parse(input, options) {

--- a/test/set-cookie-parser.js
+++ b/test/set-cookie-parser.js
@@ -221,4 +221,15 @@ describe("set-cookie-parser", function () {
     expected = {};
     assert.deepEqual(actual, expected);
   });
+
+  it("should have empty name string, and value is the name-value-pair if the name-value-pair string lacks a = character", function () {
+    var actual = setCookie.parse("foo;");
+    var expected = [{ name: "", value: "foo" }];
+
+    assert.deepEqual(actual, expected);
+
+    actual = setCookie.parse("foo;SameSite=None;Secure");
+    expected = [{ name: "", value: "foo", sameSite: "None", secure: true }];
+    assert.deepEqual(actual, expected);
+  });
 });


### PR DESCRIPTION
I found that Chrome and Firefox abides to the upcoming 6265bis where name-value parsing have changed compared to 6265.

This PR changes the behavior of set-cookie-parser to abide by 6265bis as well.