### PR TITLE
fix: remove duplicate definitions for options

### DIFF
--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -120,10 +120,6 @@ function parse(input, options) {
     input = [input];
   }
 
-  options = options
-    ? Object.assign({}, defaultParseOptions, options)
-    : defaultParseOptions;
-
   if (!options.map) {
     return input.filter(isNonEmptyString).map(function (str) {
       return parseString(str, options);


### PR DESCRIPTION
We can see that in parse method. options is been defined twice. This PR is to remove duplicate definition.