### PR TITLE
fix: trim whitespace from cookie attribute names and values (RFC 6265 5.2)

### DIFF
--- a/lib/set-cookie.js
+++ b/lib/set-cookie.js
@@ -48,11 +48,11 @@ function parseString(setCookieValue, options) {
 
   parts.forEach(function (part) {
     var sides = part.split("=");
-    var key = sides.shift().trimLeft().toLowerCase();
+    var key = sides.shift().trim().toLowerCase();
     if (isForbiddenKey(key)) {
       return;
     }
-    var value = sides.join("=");
+    var value = sides.join("=").trim();
     if (key === "expires") {
       cookie.expires = new Date(value);
     } else if (key === "max-age") {

--- a/test/set-cookie-parser.js
+++ b/test/set-cookie-parser.js
@@ -247,6 +247,36 @@ describe("set-cookie-parser", function () {
     assert.deepEqual(actual, expected);
   });
 
+  it("should trim whitespace around attribute names and values (rfc 6265 5.2 step 3)", function () {
+    var actual = parseSetCookie(
+      "foo=bar; Domain= .example.com; Path= /admin; SameSite= Lax"
+    );
+    var expected = [
+      {
+        name: "foo",
+        value: "bar",
+        domain: ".example.com",
+        path: "/admin",
+        sameSite: "Lax",
+      },
+    ];
+    assert.deepEqual(actual, expected);
+
+    actual = parseSetCookie("foo=bar; Domain=.example.com ; Path=/ ");
+    expected = [
+      { name: "foo", value: "bar", domain: ".example.com", path: "/" },
+    ];
+    assert.deepEqual(actual, expected);
+
+    actual = parseSetCookie("foo=bar; Secure ");
+    expected = [{ name: "foo", value: "bar", secure: true }];
+    assert.deepEqual(actual, expected);
+
+    actual = parseSetCookie("foo=bar; Path =/x");
+    expected = [{ name: "foo", value: "bar", path: "/x" }];
+    assert.deepEqual(actual, expected);
+  });
+
   describe("split option", function () {
     const cookieA = "a=b";
     const cookieB = "b=c";


### PR DESCRIPTION
Attribute parsing does not strip whitespace per RFC 6265 section 5.2 step 3 ("Remove any leading or trailing WSP characters from the attribute-name and the attribute-value"). The attribute loop in `parseString` applies only `.trimLeft()` to the attribute name and no trimming at all to the attribute value, so any space after `=` (or after the attribute name) is kept verbatim.

A server may emit OWS around the value, e.g. `Domain= .example.com`. Current behavior:

```js
parseSetCookie("foo=bar; Domain= .example.com; Path= /admin; SameSite= Lax")[0];
// { name: 'foo', value: 'bar', domain: ' .example.com', path: ' /admin', sameSite: ' Lax' }

parseSetCookie("foo=bar; Domain=.example.com ")[0];
// { name: 'foo', value: 'bar', domain: '.example.com ' }   <- trailing space kept

parseSetCookie("foo=bar; Secure ")[0];
// { name: 'foo', value: 'bar', 'secure ': '' }   <- not recognized as the secure flag

parseSetCookie("foo=bar; Path =/x")[0];
// { name: 'foo', value: 'bar', 'path ': '/x' }   <- unknown key, not path
```

A leading space in `domain`/`path` breaks domain-match and path-match (RFC 6265 section 5.1.3 / 5.1.4); `sameSite: ' Lax'` does not equal `'Lax'`; and a trailing space on a boolean attribute name (`Secure `, `HttpOnly `) silently drops the flag because the key no longer matches.

## Fix

Two-token change in `lib/set-cookie.js`, the `parseString` attribute loop:

- attribute name: `.trimLeft()` -> `.trim()` (also strips trailing WSP from the name)
- attribute value: `sides.join("=")` -> `sides.join("=").trim()`

After:

```js
parseSetCookie("foo=bar; Domain= .example.com; Path= /admin; SameSite= Lax")[0];
// { name: 'foo', value: 'bar', domain: '.example.com', path: '/admin', sameSite: 'Lax' }
parseSetCookie("foo=bar; Secure ")[0];
// { name: 'foo', value: 'bar', secure: true }
```

`Max-Age` and `Expires` were already tolerant of a leading space (`parseInt`/`new Date` skip leading WSP), so their outputs are unchanged. The existing attribute tests use no space after `=` and all stay green. Added a test covering leading/trailing WSP on names and values.
